### PR TITLE
Updated kernel528-ys.omp.json theme to added standard date of YYYY-MM…

### DIFF
--- a/themes/kernel528-ys.omp.json
+++ b/themes/kernel528-ys.omp.json
@@ -75,7 +75,10 @@
           "foreground": "darkGray",
           "style": "plain",
           "template": "[{{ .CurrentDate | date .Format }}]",
-          "type": "time"
+          "type": "time",
+          "properties": {
+            "time_format": "2006-01-02 15:04:05"
+          }
         },
         {
           "properties": {


### PR DESCRIPTION
…-DD in front of time.

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
