### PR TITLE
test(umbraco): update fixture to patched release

### DIFF
--- a/src/segments/umbraco_test.go
+++ b/src/segments/umbraco_test.go
@@ -64,7 +64,7 @@ func TestUmbracoSegment(t *testing.T) {
 			HasWebConfig:     false,
 			ExpectedEnabled:  true, // Segment should be enabled and visible
 			Template:         "{{ .Version }}",
-			ExpectedString:   "12.1.2",
+			ExpectedString:   "17.4.0",
 		},
 		{
 			Case:                    "Umbraco Folder with a .csproj [without Umbraco] and a web.config",
@@ -94,7 +94,7 @@ func TestUmbracoSegment(t *testing.T) {
 			HasCSProjWithoutUmbraco: true,
 			ExpectedEnabled:         true, // Segment should be enabled and visible
 			Template:                "{{ .Version }}",
-			ExpectedString:          "12.1.2",
+			ExpectedString:          "17.4.0",
 		},
 		{
 			Case:             "Umbraco Folder and .csproj with custom template",
@@ -102,7 +102,7 @@ func TestUmbracoSegment(t *testing.T) {
 			HasCsproj:        true,
 			ExpectedEnabled:  true,
 			Template:         "Version:{{ .Version }} ModernUmbraco:{{ .Modern }}",
-			ExpectedString:   "Version:12.1.2 ModernUmbraco:true",
+			ExpectedString:   "Version:17.4.0 ModernUmbraco:true",
 		},
 	}
 

--- a/src/test/umbraco/MyProject.csproj
+++ b/src/test/umbraco/MyProject.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Umbraco.TheStarterKit" Version="11.0.0" />
         <!-- This is a comment -->
         <!--PackageReference Include="Umbraco.Cms" Version="12.3.4" /-->
-        <PackageReference Include="Umbraco.Cms" Version="13.14.0" />
+        <PackageReference Include="Umbraco.Cms" Version="17.4.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- update the Umbraco test fixture to 17.4.0
- update segment assertions for the fixture version

## Validation
- go test ./segments

## Notes
- modernize, fieldalignment, and golangci-lint are unavailable in the local environment.